### PR TITLE
Refactor grep implementation

### DIFF
--- a/src/grep/s21_grep.c
+++ b/src/grep/s21_grep.c
@@ -15,29 +15,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
-typedef struct {
-  int e;      // -e
-  int i;      // -i
-  int v;      // -v
-  int c;      // -c
-  int l;      // -l
-  int n;      // -n
-  int h;      // -h
-  int s;      // -s
-  int o;      // -o
-} Flags;
+#include "s21_grep.h"
 
 typedef struct {
   size_t so;
   size_t eo;
 } Match;
 
-// --------------------------------------------------
-// Variables globales para determinar el código de salida
-// --------------------------------------------------
-static int any_match_global = 0; // =1 si al menos un match en cualquier fichero
-static int any_error = 0; // =1 si hubo error de uso o no pudo abrir fichero
 
 static int compare_match(const void *a, const void *b) {
   const Match *A = (const Match *) a;
@@ -105,12 +89,12 @@ static char **load_patterns_from_file(const char *fname, int *out_count) {
   return pats;
 }
 
-static void grep_file(const char *filename, char **patterns, int pat_count,
-                      Flags flags, int total_files);
 
 int main(int argc, char *argv[]) {
   Flags flags = {0};
   int opt;
+  int any_match_global = 0;
+  int any_error = 0;
 
   // Reservamos espacio para 'argc' patrones como máximo
   int cap = argc;
@@ -246,10 +230,18 @@ int main(int argc, char *argv[]) {
   // File proccessing
   int total_files = argc;
   if (total_files == 0) {
-    grep_file(NULL, patterns, pat_count, flags, total_files);
+    Result r = grep_file(NULL, patterns, pat_count, flags, total_files);
+    if (r.match_found)
+      any_match_global = 1;
+    if (r.error)
+      any_error = 1;
   } else {
     for (int i = 0; i < total_files; i++) {
-      grep_file(argv[i], patterns, pat_count, flags, total_files);
+      Result r = grep_file(argv[i], patterns, pat_count, flags, total_files);
+      if (r.match_found)
+        any_match_global = 1;
+      if (r.error)
+        any_error = 1;
     }
   }
 
@@ -288,15 +280,16 @@ int main(int argc, char *argv[]) {
 //   de rango. • Aplica flags: -v, -l, -c, -n, -h, -o tal cual lo haría grep. •
 //   Al final cierra fichero y libera todo.
 // =======================================================================
-static void grep_file(const char *filename, char **patterns, int pat_count,
-                      Flags flags, int total_files) {
+Result grep_file(const char *filename, char **patterns, int pat_count,
+                 Flags flags, int total_files) {
+  Result res = {0, 0};
   FILE *f = filename ? fopen(filename, "r") : stdin;
   if (!f) {
     if (!flags.s) {
       perror(filename);
     }
-    any_error = 1;
-    return;
+    res.error = 1;
+    return res;
   }
 
   // --------------------------------------------------
@@ -307,8 +300,8 @@ static void grep_file(const char *filename, char **patterns, int pat_count,
     fprintf(stderr, "Memory allocation failure\n");
     if (f != stdin)
       fclose(f);
-    any_error = 1;
-    return;
+    res.error = 1;
+    return res;
   }
   int regc_flags = flags.i ? REG_ICASE : 0;
   for (int p = 0; p < pat_count; p++) {
@@ -321,8 +314,8 @@ static void grep_file(const char *filename, char **patterns, int pat_count,
       free(regs);
       if (f != stdin)
         fclose(f);
-      any_error = 1;
-      return;
+      res.error = 1;
+      return res;
     }
   }
 
@@ -336,8 +329,9 @@ static void grep_file(const char *filename, char **patterns, int pat_count,
   int line_no = 1;
   int match_count = 0;  // para -c
   int matched_file = 0; // para -l
+  int stop_processing = 0;
 
-  while ((nread = getline(&line, &len, f)) != -1) {
+  while (!stop_processing && (nread = getline(&line, &len, f)) != -1) {
     // Suprimir '\n' para que ^$ funcione exactamente como grep
     if (nread > 0 && line[nread - 1] == '\n') {
       line[nread - 1] = '\0';
@@ -357,8 +351,8 @@ static void grep_file(const char *filename, char **patterns, int pat_count,
       free(regs);
       if (f != stdin)
         fclose(f);
-      any_error = 1;
-      return;
+      res.error = 1;
+      return res;
     }
     int mcount = 0;
 
@@ -369,8 +363,9 @@ static void grep_file(const char *filename, char **patterns, int pat_count,
       // Buscamos múltiples ocurrencias del patrón p
       while (cursor <= line + nread) {
         int ret = regexec(&regs[p], cursor, 1, &pm, 0);
-        if (ret != 0)
-          break; // -1 o REG_NOMATCH → no hay más
+        if (ret != 0) {
+          cursor = line + nread + 1;
+        } else {
 
         // Si aquí hay match, guardamos su rango
         size_t so = (cursor - line) + pm.rm_so;
@@ -388,8 +383,8 @@ static void grep_file(const char *filename, char **patterns, int pat_count,
             free(regs);
             if (f != stdin)
               fclose(f);
-            any_error = 1;
-            return;
+            res.error = 1;
+            return res;
           }
           matches = tmp;
         }
@@ -405,7 +400,8 @@ static void grep_file(const char *filename, char **patterns, int pat_count,
         }
         // Si el cursor avanza más allá del final, cortamos
         if (cursor > line + nread)
-          break;
+          cursor = line + nread + 1;
+        }
       }
     }
 
@@ -413,7 +409,7 @@ static void grep_file(const char *filename, char **patterns, int pat_count,
     if (flags.v)
       any_match = !any_match;
     if (any_match)
-      any_match_global = 1;
+      res.match_found = 1;
 
     // --------------------------------------------------
     // 4) Si -l y encontramos match: imprimimos nombre de archivo y cortamos
@@ -424,7 +420,7 @@ static void grep_file(const char *filename, char **patterns, int pat_count,
         matched_file = 1;
       }
       free(matches);
-      break; // dejamos de procesar líneas de este fichero
+      stop_processing = 1;
     }
 
     // --------------------------------------------------
@@ -481,4 +477,5 @@ static void grep_file(const char *filename, char **patterns, int pat_count,
   free(line);
   if (f != stdin)
     fclose(f);
+  return res;
 }

--- a/src/grep/s21_grep.h
+++ b/src/grep/s21_grep.h
@@ -1,24 +1,28 @@
-/* s21_grep.h */
-#ifndef _S21_GREP_H_
-#define _S21_GREP_H_
+#ifndef S21_GREP_H_
+#define S21_GREP_H_
 
+#include <regex.h>
 #include <stdio.h>
 #include <unistd.h>
-#include <regex.h>
 
 typedef struct {
-    int e;      // -e
-    int i;      // -i
-    int v;      // -v
-    int c;      // -c
-    int l;      // -l
-    int n;      // -n
-    int h;      // -h
-    int s;      // -s
-    int o;      // -o
+  int e;  /* -e */
+  int i;  /* -i */
+  int v;  /* -v */
+  int c;  /* -c */
+  int l;  /* -l */
+  int n;  /* -n */
+  int h;  /* -h */
+  int s;  /* -s */
+  int o;  /* -o */
 } Flags;
 
-void grep_file(const char *filename, char **patterns, int pat_count,
-               Flags flags, int total_files);
+typedef struct {
+  int match_found;  /* 1 if file had a match */
+  int error;        /* 1 on processing error */
+} Result;
 
-#endif // _S21_GREP_H_
+Result grep_file(const char *filename, char **patterns, int pat_count,
+                 Flags flags, int total_files);
+
+#endif  /* S21_GREP_H_ */


### PR DESCRIPTION
## Summary
- restructure header declarations
- remove global variables in grep implementation
- avoid loop `break` statements and manage flow with conditions

## Testing
- `make`
- `bash test_grep.sh >test.log && tail -n 2 test.log`

------
https://chatgpt.com/codex/tasks/task_e_6841b9f894108321bea508bea438bf2b