### PR TITLE
Refactor to avoid continue usage

### DIFF
--- a/src/grep/s21_grep.h
+++ b/src/grep/s21_grep.h
@@ -1,24 +1,28 @@
-/* s21_grep.h */
-#ifndef _S21_GREP_H_
-#define _S21_GREP_H_
+#ifndef S21_GREP_H_
+#define S21_GREP_H_
 
+#include <regex.h>
 #include <stdio.h>
 #include <unistd.h>
-#include <regex.h>
 
 typedef struct {
-    int e;      // -e
-    int i;      // -i
-    int v;      // -v
-    int c;      // -c
-    int l;      // -l
-    int n;      // -n
-    int h;      // -h
-    int s;      // -s
-    int o;      // -o
+  int e;  /* -e */
+  int i;  /* -i */
+  int v;  /* -v */
+  int c;  /* -c */
+  int l;  /* -l */
+  int n;  /* -n */
+  int h;  /* -h */
+  int s;  /* -s */
+  int o;  /* -o */
 } Flags;
 
-void grep_file(const char *filename, char **patterns, int pat_count,
-               Flags flags, int total_files);
+typedef struct {
+  int match_found;  /* 1 if file had a match */
+  int error;        /* 1 on processing error */
+} Result;
 
-#endif // _S21_GREP_H_
+Result grep_file(const char *filename, char **patterns, int pat_count,
+                 Flags flags, int total_files);
+
+#endif  /* S21_GREP_H_ */


### PR DESCRIPTION
## Summary
- eliminate `continue` in pattern loading
- keep global variables removed and header organized

## Testing
- `make -C src/grep s21_grep`
- `bash src/grep/test_grep.sh > test.log && tail -n 5 test.log`


------
https://chatgpt.com/codex/tasks/task_e_6841b9f894108321bea508bea438bf2b